### PR TITLE
Add app.json and Heroku Deploy Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/FromAtom/Yakitori)
+
 # Yakitori
 esaのホッテントリを計算してRedisに保存する。HerokuのSchedulerとRedisToGoを使って動かすことを想定しています。
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,31 @@
+{
+  "name": "Yakitori",
+  "description": "Calculate Hot-entries from your Esa team's posts",
+  "keywords": [
+    "productivity",
+    "team"
+  ],
+  "repository": "https://github.com/FromAtom/Yakitori",
+  "success_url": "/",
+  "env": {
+    "LOAD_PER_PAGE": {
+      "description": "スコア計算に用いる全ポストのうち、順次処理で一度に読み込む数(デフォルト100)を設定します。",
+      "value": "100"
+    },
+    "ESA_ACCESS_TOKEN": {
+      "description": "Esa で発行した Personal Access Token を設定します。(要Read権限)"
+    },
+    "ESA_TEAM_NAME": {
+      "description": "ホットエントリを計算したい自チーム名を設定します。"
+    }
+  },
+  "image": "heroku/ruby",
+  "addons": [
+    {
+      "plan": "scheduler:standard"
+    },
+    {
+      "plan": "redistogo:nano"
+    }
+  ]
+}


### PR DESCRIPTION
簡単デプロイボタン、Deploy to Heroku Button を追加します

これにより、Web ブラウザ上でYakitori のデプロイが完了します

---

`app.json` に設定した... :

* repository からソースコードをクローンさせます
* env 指定で動作に必要な環境変数を操作ユーザに要求します
* addons 指定で予めアドオンをHeroku に用意させます(**Scheduler のジョブはデプロイ後に要手動設定**)

# Links

* [app.json Schema | Heroku Dev Center](https://devcenter.heroku.com/articles/app-json-schema)
* [Creating a 'Deploy to Heroku' Button | Heroku Dev Center](https://devcenter.heroku.com/articles/heroku-button)