### PR TITLE
Add wip param

### DIFF
--- a/lib/yakitori/client.rb
+++ b/lib/yakitori/client.rb
@@ -37,6 +37,7 @@ module Yakitori
         star_count: post['stargazers_count'],
         watchers_count: post['watchers_count'],
         url: post['url'],
+        wip: post['wip'],
         score: score,
         created_at: post['created_at']
       }


### PR DESCRIPTION
記事がWIPかどうか分かるように、`wip` パラメータも保存するようにする。