### PR TITLE
RedisToGoが使えなくなったので、Heroku Data for Redisを利用する。

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,7 @@
       "plan": "scheduler:standard"
     },
     {
-      "plan": "redistogo:nano"
+      "plan": "heroku-redis:hobby-dev"
     }
   ]
 }

--- a/main.rb
+++ b/main.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'redis'
 require_relative 'lib/yakitori'
 
-REDIS_URL = (ENV['REDISTOGO_URL'] || 'redis://127.0.0.1:6379').freeze
+REDIS_URL = (ENV['REDIS_URL'] || 'redis://127.0.0.1:6379').freeze
 REDIS_KEY = (ENV['REDIS_KEY'] || 'esa_posts').freeze
 
 yakitori = ::Yakitori::Client.new


### PR DESCRIPTION
## 変更点
- `app.json` で指定しているadd-onをRedisToGoからHeroku Data for Redisに変更
- RedisのURLを指定している環境変数をHeroku Data for RedisのURLを指すものに変更